### PR TITLE
Minor docs change to clarify hba

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,7 +126,7 @@ postgresql_default_cluster:
     #    user: 'all'
     #    database: '{{ user }}'
     #    auth: 'md5'
-    #  - address: '' # example: '192.168.0.0/16
+    #    address: '' # example: '192.168.0.0/16
     #ident: |
     #  # Freeform (see postgresql_default_hba)
     #allow:


### PR DESCRIPTION
The `-` implied another entry, when 'address' was really meant to be included as part of the previous item.