### PR TITLE
Change how role detects PostgreSQL version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+v0.2.1
+------
+
+*Unreleased*
+
+- Change how role detects PostgreSQL version. The new method will use
+  ``apt-cache policy`` to use the version determined by APT preferences instead
+  of choosing first version from available packages. This fixes an issue when
+  multiple PostgreSQL versions are available but the preferred one is not the
+  first one. [drybjed]
+
 v0.2.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,17 @@ Changelog
 v0.2.1
 ------
 
-*Unreleased*
+*Released: 2016-02-01*
 
 - Change how role detects PostgreSQL version. The new method will use
   ``apt-cache policy`` to use the version determined by APT preferences instead
   of choosing first version from available packages. This fixes an issue when
   multiple PostgreSQL versions are available but the preferred one is not the
   first one. [drybjed]
+
+- Add configuration variables for ``debops.apt_preferences`` role. The
+  configuration will make sure that PostgreSQL 9.4 from ``jessie-backports``
+  repository is installed on Debian Wheezy hosts. [drybjed]
 
 v0.2.0
 ------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,3 +136,19 @@ postgresql_databases: []
 # configuration file. See :ref:`postgresql_pgpass` for more details.
 postgresql_pgpass: []
 
+
+# --------------------------------
+#   Role-dependent configuration
+# --------------------------------
+
+# .. envvar:: postgresql_apt_preferences_dependent_list
+#
+# Configuration for ``debops.apt_preferences`` role. PostgreSQL from backports
+# will be preferred on specified Debian releases.
+postgresql_apt_preferences_dependent_list:
+
+  - package: 'postgresql postgresql-* libpq5'
+    backports: [ 'wheezy' ]
+    reason: 'Version parity with Debian Jessie'
+    role: 'debops.postgresql'
+

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -100,6 +100,12 @@ Here's an example Ansible playbook that uses the ``debops.postgresql`` role::
       sudo: True
 
       roles:
+
+        - role: debops.apt_preferences
+          tags: [ 'role::apt_preferences' ]
+          apt_preferences_dependent_list:
+            - '{{ postgresql_apt_preferences_dependent_list }}'
+
         - role: debops.postgresql
           tags: [ 'role::postgresql' ]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,9 @@
   when: postgresql_upstream|d() and postgresql_upstream
 
 - name: Get default PostgreSQL version
-  shell: "apt-cache show '^postgresql$' | grep -E '^Depends:\\s' | awk '{print $2}' | cut -d- -f2 | head -n 1"
+  environment:
+    LC_ALL: 'C'
+  shell: "apt-cache policy postgresql-client | grep -E '^\\s+Candidate:\\s+' | awk '{print $2}' | cut -d+ -f1"
   register: postgresql_register_version
   changed_when: False
 


### PR DESCRIPTION
The new method will use 'apt-cache policy' to use the version determined
by APT preferences instead of choosing first version from available
packages. This fixes an issue when multiple PostgreSQL versions are
available but the preferred one is not the first one.